### PR TITLE
Fix package.json for Heroku Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "mocha ./test/* --timeout 10000 --exit",
-    "start": "nodemon server.js"
+    "start": "node server.js",
+    "dev": "nodemon server.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "mocha ./test/* --timeout 10000 --exit",
-    "start": "node server.js"
+    "start": "nodemon server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts SE701-T5/Backend#66

Sorry, I just realized the mistake that I made.

The fix involves changing the package.json file from:

```
"start": "nodemon server.js" 
```

to 

```
"start": "node server.js",
"dev": "nodemon server.js"
```

This is because the .yml file for the Heroku deployment uses the command:
```
procfile: "web: npm start"
```